### PR TITLE
Fix: Repeatable plugin path registration

### DIFF
--- a/xoa_core/core/test_suites/_loader.py
+++ b/xoa_core/core/test_suites/_loader.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from pathlib import Path
 import sys

--- a/xoa_core/core/test_suites/_loader.py
+++ b/xoa_core/core/test_suites/_loader.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import sys
 import oyaml as yaml
 import importlib.util
@@ -68,8 +69,14 @@ def __read_meta(path: str) -> "PluginMeta":
         data = yaml.load(outfile, Loader=yaml.SafeLoader)
         return PluginMeta(**data)
 
+def __register_path(path: str | Path) -> None:
+    str_path = str(path)
+    if str_path in sys.path:
+        return None
+    sys.path.append(str_path)
+
 def load_plugin(path: str) -> Generator[PluginData, None, None]:
-    sys.path.append(path)
+    __register_path(path)
     for child in os.listdir(path):
         child_path = os.path.abspath(os.path.join(path, child))
         if not os.path.isdir(child_path):

--- a/xoa_core/core/test_suites/controler.py
+++ b/xoa_core/core/test_suites/controler.py
@@ -21,11 +21,11 @@ class PluginController:
 
     def register_path(self, path: str) -> None:
         """Register custom path of plugins"""
-        self.__paths += (
-            os.path.abspath(path)
-            if not os.path.isabs(path)
-            else path,
-        )
+        if not os.path.isabs(path):
+            path = os.path.abspath(path)
+        if path in self.__paths:
+            return None
+        self.__paths += (path,)
         self.__init_plugins()
 
     def available_test_suites(self) -> List[str]:


### PR DESCRIPTION
The logic of validating plugin's path was incorrect, which cost of registering plugin twice. Which make Pydantic module to initialize 2 models of the same class.