### PR TITLE
fix: only invoke testing on push commit

### DIFF
--- a/.github/workflows/execute-test-suite.yml
+++ b/.github/workflows/execute-test-suite.yml
@@ -1,15 +1,19 @@
-name: Check if test suite workable
+name: Testing
 
 on:
   push:
     branches:
-     - "**"
-  pull_request:
-    branches:
-     - "**"
+      - "**"
+    paths-ignore:
+      - 'docs/**'
+      - README.md
+      - .gitignore
+      - .github/**
+  workflow_dispatch:
 
 jobs:
   call-regression-test:
+    name: "Regression test"
     uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@main
     secrets: inherit
 


### PR DESCRIPTION
It will stop invoke duplicate testing when open PR
![1679538935393](https://user-images.githubusercontent.com/2508212/227085622-e85dcba2-60b5-4834-9aac-1a0d3c50bc01.png)
